### PR TITLE
Add logging to AddMemberCommand and EditCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddMemberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMemberCommand.java
@@ -7,6 +7,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -38,6 +41,8 @@ public class AddMemberCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
 
+    private static final Logger logger = LogsCenter.getLogger(AddMemberCommand.class);
+
     private final Person toAdd;
 
     /**
@@ -52,11 +57,28 @@ public class AddMemberCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
+        // Log user intent
+        logger.info(String.format("User triggered 'add' command for person: %s", toAdd.getName()));
+
+        // Check for duplicates
         if (model.hasPerson(toAdd)) {
+            logger.warning(String.format(
+                "Duplicate detected — person with matriculation number %s already exists.",
+                toAdd.getMatriculationNumber()));
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        // Proceed to add
         model.addPerson(toAdd);
+        logger.info(String.format(
+            "Successfully added new person: Name=%s, MatricNo=%s, Email=%s, Phone=%s, Tags=%s",
+            toAdd.getName(),
+            toAdd.getMatriculationNumber(),
+            toAdd.getEmail(),
+            toAdd.getPhone(),
+            toAdd.getTags()));
+
+        // Return command result
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -14,7 +14,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Logger;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.commons.util.ToStringBuilder;
@@ -52,6 +54,8 @@ public class EditCommand extends Command {
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
+    private static final Logger logger = LogsCenter.getLogger(EditCommand.class);
+
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
 
@@ -72,19 +76,34 @@ public class EditCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 
+        // Log that an edit attempt is starting
+        logger.info(String.format("Executing edit command for index: %d", index.getOneBased()));
+
         if (index.getZeroBased() >= lastShownList.size()) {
+            logger.warning(String.format("Edit failed - invalid index: %d (list size: %d)",
+                index.getOneBased(), lastShownList.size()));
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
+        logger.fine(String.format("Editing person: %s (%s)",
+            personToEdit.getName(), personToEdit.getMatriculationNumber()));
+
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+            logger.warning(String.format(
+                "Edit failed - duplicate detected for matriculation number: %s",
+                editedPerson.getMatriculationNumber()));
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        logger.info(String.format("Successfully edited person: [%s → %s]",
+            personToEdit.getMatriculationNumber(), editedPerson.getMatriculationNumber()));
+
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 


### PR DESCRIPTION
This PR introduces structured logging to both AddMemberCommand and EditCommand to enhance traceability and debugging clarity.

Details: Inserted info, warning, and fine logs at key execution points:
- Command start
- Validation failures (invalid index, duplicates)
- Successful additions or edits
Fixes #77