### PR TITLE
Fix FindCommand error

### DIFF
--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -23,7 +23,7 @@ public class TagContainsKeywordsPredicate implements Predicate<Person> {
         for (Tag tag : tags) {
             String tagName = tag.tagName.toLowerCase();
             for (String keyword : keywords) {
-                if (tagName.contains(keyword.toLowerCase())) {
+                if (tagName.equalsIgnoreCase(keyword)) {
                     return true;
                 }
             }


### PR DESCRIPTION
Fixed the issue where finding via tag allowed any substring match.
find now only works on name or exact tag (upper/lower case is lenient)

Fixes #136 