### PR TITLE
Restrict Name field to alphabetic characters only and enhance validation rules

### DIFF
--- a/docs/diagrams/ViewPaymentSequenceDiagram.puml
+++ b/docs/diagrams/ViewPaymentSequenceDiagram.puml
@@ -1,5 +1,4 @@
-@@
- @startuml
+@startuml
 +actor User
 +participant Ui
 +participant Logic

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -5,18 +5,54 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Person's name in the address book.
- * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
+ * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}.
+ *
+ * <p>
+ * This class enforces a realistic and inclusive naming convention:
+ * <ul>
+ *   <li>Names must contain only alphabetic characters, spaces, hyphens (-), apostrophes ('), and periods (.)</li>
+ *   <li>Names must start with a letter (no leading whitespace or symbols)</li>
+ *   <li>Names cannot contain digits or other special symbols (e.g., @, #, $, %, etc.)</li>
+ *   <li>Names must not be blank</li>
+ *   <li>Supports Unicode letters (e.g., accented or non-Latin alphabets)</li>
+ * </ul>
+ *
+ * Examples of valid names:
+ * <pre>
+ *   - "Alex Yeoh"
+ *   - "Jean-Luc Picard"
+ *   - "O’Connor"
+ *   - "J. K. Rowling"
+ *   - "李小龙"
+ * </pre>
+ *
+ * Examples of invalid names:
+ * <pre>
+ *   - "123John"        (contains digits)
+ *   - "@lex"           (contains invalid character)
+ *   - " John"          (starts with space)
+ *   - ""               (blank)
+ * </pre>
  */
 public class Name {
 
+    /**
+     * Error message shown when a given name does not meet the required format.
+     */
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+        "Names should only contain alphabetic characters, spaces, hyphens (-), apostrophes ('), "
+            + "and periods (.), and should not be blank.";
 
     /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+     * The name must:
+     * 1. Start with an alphabetic character (Unicode supported).
+     * 2. Contain only letters, spaces, hyphens, apostrophes, or periods.
+     *
+     * The pattern "[\\p{L}][\\p{L} .'-]*" ensures:
+     * - \\p{L} : any Unicode letter (A–Z, a–z, or letters from other languages)
+     * - [\\p{L} .'-]* : subsequent characters can be letters, spaces, '.', '\'', or '-'
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{L}][\\p{L} .'-]*";
 
     public final String fullName;
 
@@ -24,6 +60,8 @@ public class Name {
      * Constructs a {@code Name}.
      *
      * @param name A valid name.
+     * @throws NullPointerException if {@code name} is null.
+     * @throws IllegalArgumentException if {@code name} does not satisfy {@link #isValidName(String)}.
      */
     public Name(String name) {
         requireNonNull(name);
@@ -32,12 +70,11 @@ public class Name {
     }
 
     /**
-     * Returns true if a given string is a valid name.
+     * Returns true if a given string is a valid name according to {@link #VALIDATION_REGEX}.
      */
     public static boolean isValidName(String test) {
         return test.matches(VALIDATION_REGEX);
     }
-
 
     @Override
     public String toString() {

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -1,60 +1,151 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class NameTest {
 
+    // ---------------------------
+    // Constructor behavior
+    // ---------------------------
+
     @Test
+    @DisplayName("constructor(null) -> NullPointerException")
     public void constructor_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new Name(null));
     }
 
     @Test
+    @DisplayName("constructor(invalid) -> IllegalArgumentException")
     public void constructor_invalidName_throwsIllegalArgumentException() {
-        String invalidName = "";
-        assertThrows(IllegalArgumentException.class, () -> new Name(invalidName));
+        // A representative set; full invalid set is covered below in isValidName()
+        assertThrows(IllegalArgumentException.class, () -> new Name(""));
+        assertThrows(IllegalArgumentException.class, () -> new Name(" "));
+        assertThrows(IllegalArgumentException.class, () -> new Name("John2"));
+        assertThrows(IllegalArgumentException.class, () -> new Name(" John"));
+        assertThrows(IllegalArgumentException.class, () -> new Name("John@"));
     }
 
+    // ---------------------------
+    // Validation behavior
+    // ---------------------------
+
     @Test
-    public void isValidName() {
-        // null name
+    @DisplayName("isValidName(null) -> NullPointerException")
+    public void isValidName_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> Name.isValidName(null));
-
-        // invalid name
-        assertFalse(Name.isValidName("")); // empty string
-        assertFalse(Name.isValidName(" ")); // spaces only
-        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
-        assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
-
-        // valid name
-        assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
-        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
-        assertTrue(Name.isValidName("Capital Tan")); // with capital letters
-        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
     }
 
     @Test
-    public void equals() {
-        Name name = new Name("Valid Name");
+    @DisplayName("isValidName(invalid cases)")
+    public void isValidName_invalid() {
+        // Empty / whitespace-only
+        assertFalse(Name.isValidName("")); // empty string
+        assertFalse(Name.isValidName(" ")); // one space
+        assertFalse(Name.isValidName("   ")); // multiple spaces
 
-        // same values -> returns true
-        assertTrue(name.equals(new Name("Valid Name")));
+        // Must start with a letter
+        assertFalse(Name.isValidName(" John")); // leading space
+        assertFalse(Name.isValidName("-John")); // leading hyphen
+        assertFalse(Name.isValidName("'John")); // leading apostrophe
+        assertFalse(Name.isValidName(".John")); // leading period
+        assertFalse(Name.isValidName("2John")); // leading digit
 
-        // same object -> returns true
-        assertTrue(name.equals(name));
+        // Disallow digits anywhere
+        assertFalse(Name.isValidName("John2"));
+        assertFalse(Name.isValidName("peter the 2nd"));
+        assertFalse(Name.isValidName("12345"));
 
-        // null -> returns false
-        assertFalse(name.equals(null));
+        // Disallow other symbols
+        assertFalse(Name.isValidName("^"));
+        assertFalse(Name.isValidName("peter*"));
+        assertFalse(Name.isValidName("John@Doe"));
+        assertFalse(Name.isValidName("John_Doe")); // underscore not allowed
 
-        // different types -> returns false
-        assertFalse(name.equals(5.0f));
+        // Edge: only punctuation (no letters)
+        assertFalse(Name.isValidName(".'-")); // has allowed punctuation but no letters
+        assertFalse(Name.isValidName(".")); // single period, no letters
+        assertFalse(Name.isValidName("-")); // single hyphen, no letters
+        assertFalse(Name.isValidName("'")); // single apostrophe, no letters
+    }
 
-        // different values -> returns false
-        assertFalse(name.equals(new Name("Other Valid Name")));
+    @Test
+    @DisplayName("isValidName(valid cases)")
+    public void isValidName_valid() {
+        // Simple alphabetic
+        assertTrue(Name.isValidName("peter jack"));
+        assertTrue(Name.isValidName("Capital Tan"));
+        assertTrue(Name.isValidName("A")); // single-letter name
+
+        // Common punctuation in names
+        assertTrue(Name.isValidName("Jean-Luc Picard")); // hyphen
+        assertTrue(Name.isValidName("Anne-Marie")); // hyphen internal
+        assertTrue(Name.isValidName("O'Connor")); // apostrophe (ASCII)
+        assertTrue(Name.isValidName("J. K. Rowling")); // periods in initials
+        assertTrue(Name.isValidName("Mary Jane")); // single space between words
+
+        // Unicode letters (international names)
+        assertTrue(Name.isValidName("José María")); // accented letters
+
+        // Boundary around starting-with-letter rule
+        assertTrue(Name.isValidName("A.")); // letter + period
+        assertTrue(Name.isValidName("J.")); // initial style
+    }
+
+    // ---------------------------
+    // equals / hashCode / toString
+    // ---------------------------
+
+    @Test
+    @DisplayName("equals: reflexive, symmetric, transitive, and null/type safety")
+    public void equals_contract() {
+        Name a1 = new Name("Valid Name");
+        Name a2 = new Name("Valid Name");
+        Name b = new Name("Other Valid Name");
+
+        // Reflexive
+        assertTrue(a1.equals(a1));
+
+        // Symmetric
+        assertTrue(a1.equals(a2));
+        assertTrue(a2.equals(a1));
+
+        // Transitive
+        Name a3 = new Name("Valid Name");
+        assertTrue(a1.equals(a2));
+        assertTrue(a2.equals(a3));
+        assertTrue(a1.equals(a3));
+
+        // Consistent & inequality
+        assertFalse(a1.equals(b));
+        assertFalse(b.equals(a1));
+
+        // Null & type safety
+        assertFalse(a1.equals(null));
+        assertFalse(a1.equals(5.0f));
+    }
+
+    @Test
+    @DisplayName("hashCode: equal objects have equal hash codes")
+    public void hashCode_consistency() {
+        Name a1 = new Name("Valid Name");
+        Name a2 = new Name("Valid Name");
+        Name b = new Name("Other Valid Name");
+
+        assertEquals(a1.hashCode(), a2.hashCode());
+        assertNotEquals(a1.hashCode(), b.hashCode());
+    }
+
+    @Test
+    @DisplayName("toString returns the full name verbatim")
+    public void toString_returnsFullName() {
+        assertEquals("Alex Yeoh", new Name("Alex Yeoh").toString());
+        assertEquals("J. K. Rowling", new Name("J. K. Rowling").toString());
     }
 }


### PR DESCRIPTION
This PR updates the Name class to enforce stricter and more realistic validation rules for person names in the address book. Previously, the Name field accepted alphanumeric characters — allowing names such as "n11" or "Alex123", which are not valid human names.

The new validation logic ensures names follow proper linguistic and formatting conventions.

Restricts input to letters, spaces, hyphens (-), apostrophes ('), and periods (.)
Ensures names start with a letter

Fixes #135 