### PR TITLE
Edit matriculation number formatting

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddMemberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMemberCommand.java
@@ -34,7 +34,7 @@ public class AddMemberCommand extends Command {
         + PREFIX_NAME + "John Doe "
         + PREFIX_PHONE + "98765432 "
         + PREFIX_EMAIL + "johnd@example.com "
-        + PREFIX_MATRICULATIONNUMBER + "A01234567X "
+        + PREFIX_MATRICULATIONNUMBER + "A1234567X "
         + PREFIX_TAG + "friends "
         + PREFIX_TAG + "owesMoney";
 

--- a/src/main/java/seedu/address/model/person/MatriculationNumber.java
+++ b/src/main/java/seedu/address/model/person/MatriculationNumber.java
@@ -11,18 +11,18 @@ import seedu.address.model.person.exceptions.InvalidMatriculationNumberException
 public class MatriculationNumber {
 
     public static final String MESSAGE_CONSTRAINTS =
-        "Matriculation numbers must be exactly 10 characters long, "
+        "Matriculation numbers must be exactly 9 characters long, "
             + "start with 'A', end with an alphabet, "
-            + "and contain digits in between (e.g. A01234567X).";
+            + "and contain digits in between (e.g. A1234567X).";
 
     /**
      * Format:
      * - First char: 'A'
      * - Next 8 chars: digits 0–9
      * - Last char: alphabet (A–Z)
-     * Total length: 10.
+     * Total length: 9.
      */
-    public static final String VALIDATION_REGEX = "A\\d{8}[A-Z]";
+    public static final String VALIDATION_REGEX = "A\\d{7}[A-Z]";
 
     public final String value;
 

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -4,7 +4,7 @@
       "name": "Alice Pauline",
       "phone": "94351253",
       "email": "alice@example.com",
-      "matriculationNumber": "A44444444A",
+      "matriculationNumber": "A4444444A",
       "tags": [
         "friends"
       ]
@@ -13,7 +13,7 @@
       "name": "Alice George",
       "phone": "94351253",
       "email": "pauline@example.com",
-      "matriculationNumber": "A44444444A"
+      "matriculationNumber": "A4444444A"
     }
   ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,7 +5,7 @@
       "name": "Alice Pauline",
       "phone": "94351253",
       "email": "alice@example.com",
-      "matriculationNumber": "A00000000D",
+      "matriculationNumber": "A0000000D",
       "tags": [
         "friends"
       ]
@@ -14,7 +14,7 @@
       "name": "Benson Meier",
       "phone": "98765432",
       "email": "johnd@example.com",
-      "matriculationNumber": "A00000000E",
+      "matriculationNumber": "A0000000E",
       "tags": [
         "owesMoney",
         "friends"
@@ -24,14 +24,14 @@
       "name": "Carl Kurz",
       "phone": "95352563",
       "email": "heinz@example.com",
-      "matriculationNumber": "A00000000F",
+      "matriculationNumber": "A0000000F",
       "tags": []
     },
     {
       "name": "Daniel Meier",
       "phone": "87652533",
       "email": "cornelia@example.com",
-      "matriculationNumber": "A00000000G",
+      "matriculationNumber": "A0000000G",
       "tags": [
         "friends"
       ]
@@ -40,21 +40,21 @@
       "name": "Elle Meyer",
       "phone": "9482224",
       "email": "werner@example.com",
-      "matriculationNumber": "A00000000H",
+      "matriculationNumber": "A0000000H",
       "tags": []
     },
     {
       "name": "Fiona Kunz",
       "phone": "9482427",
       "email": "lydia@example.com",
-      "matriculationNumber": "A00000000I",
+      "matriculationNumber": "A0000000I",
       "tags": []
     },
     {
       "name": "George Best",
       "phone": "9482442",
       "email": "anna@example.com",
-      "matriculationNumber": "A00000000J",
+      "matriculationNumber": "A0000000J",
       "tags": []
     }
   ]

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -32,8 +32,8 @@ public class CommandTestUtil {
     public static final String VALID_PHONE_BOB = "22222222";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
-    public static final String VALID_MATRICULATIONNUM_AMY = "A11111111A";
-    public static final String VALID_MATRICULATIONNUM_BOB = "A11111111B";
+    public static final String VALID_MATRICULATIONNUM_AMY = "A1111111A";
+    public static final String VALID_MATRICULATIONNUM_BOB = "A1111111B";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -29,7 +29,7 @@ public class ParserUtilTest {
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
-    private static final String VALID_MATRICULATIONNUM = "A44444444Z";
+    private static final String VALID_MATRICULATIONNUM = "A4444444Z";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";

--- a/src/test/java/seedu/address/model/person/MatriculationNumberTest.java
+++ b/src/test/java/seedu/address/model/person/MatriculationNumberTest.java
@@ -18,21 +18,21 @@ public class MatriculationNumberTest {
     // ✅ ---------------- VALID CASES ----------------
     @Test
     public void constructor_validMatriculationNumber_success() {
-        MatriculationNumber m = new MatriculationNumber("A01234567X");
-        assertEquals("A01234567X", m.value);
+        MatriculationNumber m = new MatriculationNumber("A1234567X");
+        assertEquals("A1234567X", m.value);
     }
 
     @Test
     public void constructor_lowercase_convertedToUppercase() {
-        MatriculationNumber m = new MatriculationNumber("a01234567b");
-        assertEquals("A01234567B", m.value);
+        MatriculationNumber m = new MatriculationNumber("a1234567b");
+        assertEquals("A1234567B", m.value);
     }
 
     @Test
     public void isValidMatriculationNumber_validExamples_returnTrue() {
-        assertTrue(MatriculationNumber.isValidMatriculationNumber("A01234567X"));
-        assertTrue(MatriculationNumber.isValidMatriculationNumber("A17172828B"));
-        assertTrue(MatriculationNumber.isValidMatriculationNumber("A00000000Z"));
+        assertTrue(MatriculationNumber.isValidMatriculationNumber("A1234567X"));
+        assertTrue(MatriculationNumber.isValidMatriculationNumber("A7172828B"));
+        assertTrue(MatriculationNumber.isValidMatriculationNumber("A0000000Z"));
     }
 
     @Test
@@ -58,15 +58,15 @@ public class MatriculationNumberTest {
         assertThrows(InvalidMatriculationNumberException.class, () -> new MatriculationNumber("12312312HH"));
         // no digits in middle
         assertThrows(InvalidMatriculationNumberException.class, () -> new MatriculationNumber("AABCDEFGHX"));
-        // only 9 total characters
-        assertThrows(InvalidMatriculationNumberException.class, () -> new MatriculationNumber("A1234567B"));
+        // only 10 total characters
+        assertThrows(InvalidMatriculationNumberException.class, () -> new MatriculationNumber("A01234567B"));
     }
 
     @Test
     public void isValidMatriculationNumber_invalidExamples_returnFalse() {
         String[] invalids = {
             "", " ", "A", "A123B", "A123456789", "A1234567BB",
-            "a1234567b", "B01234567X", "C12312311B", "12312312HH",
+            "a01234567b", "B01234567X", "C12312311B", "12312312HH",
             "AABCDEFGHX", "A1234567@", "A12", "A00000000", "Z00000000X"
         };
         for (String test : invalids) {
@@ -76,42 +76,42 @@ public class MatriculationNumberTest {
 
     @Test
     public void equals_sameValue_true() {
-        MatriculationNumber m1 = new MatriculationNumber("A01234567X");
-        MatriculationNumber m2 = new MatriculationNumber("a01234567x");
+        MatriculationNumber m1 = new MatriculationNumber("A1234567X");
+        MatriculationNumber m2 = new MatriculationNumber("a1234567x");
         assertEquals(m1, m2);
     }
 
     @Test
     public void equals_differentValue_false() {
-        MatriculationNumber m1 = new MatriculationNumber("A01234567X");
-        MatriculationNumber m2 = new MatriculationNumber("A01234567Y");
+        MatriculationNumber m1 = new MatriculationNumber("A1234567X");
+        MatriculationNumber m2 = new MatriculationNumber("A1234567Y");
         assertNotEquals(m1, m2);
     }
 
     @Test
     public void equals_sameObject_true() {
-        MatriculationNumber m = new MatriculationNumber("A01234567X");
+        MatriculationNumber m = new MatriculationNumber("A1234567X");
         assertTrue(m.equals(m)); // self equality
     }
 
     @Test
     public void equals_differentType_false() {
-        MatriculationNumber m = new MatriculationNumber("A01234567X");
-        assertFalse(m.equals("A01234567X")); // different type
+        MatriculationNumber m = new MatriculationNumber("A1234567X");
+        assertFalse(m.equals("A1234567X")); // different type
         assertFalse(m.equals(123)); // integer
     }
 
     @Test
     public void hashCode_sameValue_sameHash() {
-        MatriculationNumber m1 = new MatriculationNumber("A01234567X");
-        MatriculationNumber m2 = new MatriculationNumber("a01234567x");
+        MatriculationNumber m1 = new MatriculationNumber("A1234567X");
+        MatriculationNumber m2 = new MatriculationNumber("a1234567x");
         assertEquals(m1.hashCode(), m2.hashCode());
     }
 
     @Test
     public void toString_returnsValue() {
-        MatriculationNumber m = new MatriculationNumber("A01234567X");
-        assertEquals("A01234567X", m.toString());
+        MatriculationNumber m = new MatriculationNumber("A1234567X");
+        assertEquals("A1234567X", m.toString());
     }
 
 }

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -73,12 +73,12 @@ public class NameContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email, and matriculation number, but do not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "A81818182D"
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "A1818182D"
         ));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice")
             .withPhone("12345")
             .withEmail("alice@email.com")
-            .withMatriculationNumber("A81818182D")
+            .withMatriculationNumber("A1818182D")
             .build()));
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -26,7 +26,7 @@ public class PersonBuilder {
     public static final String DEFAULT_NAME = "Amy Bee";
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
-    public static final String DEFAULT_MATRICULATIONNUM = "A33333333A";
+    public static final String DEFAULT_MATRICULATIONNUM = "A3333333A";
 
     private Name name;
     private Phone phone;

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -24,29 +24,29 @@ import seedu.address.model.person.Person;
 public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
-        .withMatriculationNumber("A00000000D").withEmail("alice@example.com")
+        .withMatriculationNumber("A0000000D").withEmail("alice@example.com")
         .withPhone("94351253")
         .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
-        .withMatriculationNumber("A00000000E")
+        .withMatriculationNumber("A0000000E")
         .withEmail("johnd@example.com").withPhone("98765432")
         .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-        .withEmail("heinz@example.com").withMatriculationNumber("A00000000F").build();
+        .withEmail("heinz@example.com").withMatriculationNumber("A0000000F").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-        .withEmail("cornelia@example.com").withMatriculationNumber("A00000000G").withTags("friends").build();
+        .withEmail("cornelia@example.com").withMatriculationNumber("A0000000G").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-        .withEmail("werner@example.com").withMatriculationNumber("A00000000H").build();
+        .withEmail("werner@example.com").withMatriculationNumber("A0000000H").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-        .withEmail("lydia@example.com").withMatriculationNumber("A00000000I").build();
+        .withEmail("lydia@example.com").withMatriculationNumber("A0000000I").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-        .withEmail("anna@example.com").withMatriculationNumber("A00000000J").build();
+        .withEmail("anna@example.com").withMatriculationNumber("A0000000J").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-        .withEmail("stefan@example.com").withMatriculationNumber("A22232222H").build();
+        .withEmail("stefan@example.com").withMatriculationNumber("A2232222H").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-        .withEmail("hans@example.com").withMatriculationNumber("A22222322I").build();
+        .withEmail("hans@example.com").withMatriculationNumber("A2222322I").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)


### PR DESCRIPTION
Corrected the formatting of matriculation number - should be 7 digits instead of 8. (Total length of matriculation number is 9 instead of 10)

Fixes #145 