### PR TITLE
Fix Deletepayment functionality

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,7 +1,7 @@
 ---
   layout: default.md
-    title: "User Guide"
-    pageNav: 3
+  title: "User Guide"
+  pageNav: 3
 ---
 
 # Treasura User Guide
@@ -60,7 +60,7 @@ help
 ```
 
 The **Help Window** appears, showing a list of all available commands and their formats.  
-![Ui](images/UpdatedHelpWIndow.png)
+![updated help window](images/UpdatedHelpWIndow.png)
 Now he’s ready to get started.
 
 ---
@@ -257,7 +257,7 @@ If you run a command such as `listarchived` or `find`, the indexes will change a
 
 <box type="warning" seamless>
 
-**⚠️ Caution:**  
+**Caution:**  
 `help` is the one exception to this rule, to provide leeway for unfamiliar users.<br>
 </box>
 
@@ -267,7 +267,7 @@ If you run a command such as `listarchived` or `find`, the indexes will change a
 
 <box type="tip" seamless>
 
-💡 **Tip:** For best results, always run `list` or `listarchived` before executing commands that use an **INDEX**.
+**Tip:** For best results, always run `list` or `listarchived` before executing commands that use an **INDEX**.
 </box>
 
 ---
@@ -276,7 +276,7 @@ If you run a command such as `listarchived` or `find`, the indexes will change a
 
 Shows a message containing all functions.
 
-![help message](images/helpMessage.png)
+![updated help window](images/UpdatedHelpWIndow.png)
 
 **Format:** `help`
 

--- a/src/main/java/seedu/address/logic/commands/ViewPaymentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewPaymentCommand.java
@@ -52,7 +52,9 @@ public class ViewPaymentCommand extends Command {
         requireNonNull(model);
         logger.fine(() -> "Executing viewpayment" + (index == null ? " all" : " " + index.getOneBased()));
 
-        List<Person> people = model.getFilteredPersonList();
+        final List<Person> people = (index == null)
+                ? model.getAddressBook().getPersonList() // includes archived too
+                : model.getFilteredPersonList();
 
         // 'all' mode: show per-person totals and a grand total
         if (index == null) {

--- a/src/main/java/seedu/address/logic/parser/DeletePaymentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePaymentCommandParser.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -9,40 +11,65 @@ import seedu.address.logic.commands.DeletePaymentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new DeletePaymentCommand object.
+ * Parses input arguments of the form:
+ *   PERSON_INDEX p/PAYMENT_INDEX[,PAYMENT_INDEX]...
+ * e.g. "2 p/1,2,3"
  */
 public class DeletePaymentCommandParser implements Parser<DeletePaymentCommand> {
 
     @Override
     public DeletePaymentCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_PAYMENT_INDEX);
+        requireNonNull(args);
 
-        List<Index> personIndexes;
-        Index paymentIndex;
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_PAYMENT_INDEX);
+        argMultimap.verifyNoDuplicatePrefixesFor(CliSyntax.PREFIX_PAYMENT_INDEX);
 
+        // PERSON_INDEX in preamble (exactly one!!!)
+        final String preamble = argMultimap.getPreamble().trim();
+        final Index personIndex;
         try {
-            // Parse person indexes from preamble
-            personIndexes = ParserUtil.parseIndexes(argMultimap.getPreamble());
+            // single index now
+            personIndex = ParserUtil.parseIndex(preamble);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePaymentCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, DeletePaymentCommand.MESSAGE_USAGE));
         }
 
-        try {
-            // Parse payment index from prefix
-            paymentIndex = ParserUtil.parseIndex(
-                    argMultimap.getValue(CliSyntax.PREFIX_PAYMENT_INDEX)
-                            .orElseThrow(() ->
-                                    new ParseException(
-                                            String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                                                    DeletePaymentCommand.MESSAGE_USAGE)))
-            );
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePaymentCommand.MESSAGE_USAGE));
+        // after p/
+        final String paymentsRaw = argMultimap
+                .getValue(CliSyntax.PREFIX_PAYMENT_INDEX)
+                .orElse("")
+                .trim();
+
+        if (paymentsRaw.isEmpty()) {
+            throw new ParseException("Missing payment index after 'p/'. Example: p/1,2,3");
         }
 
-        return new DeletePaymentCommand(personIndexes, paymentIndex);
+        final String[] tokens = paymentsRaw.split(",");
+        final List<Index> paymentIndexes = new ArrayList<>();
+
+        for (String token : tokens) {
+            final String t = token.trim();
+            if (t.isEmpty()) {
+                throw new ParseException(
+                        "Empty payment indexes are not allowed. Remove stray commas/spaces. Example: p/1,2,3");
+            }
+            paymentIndexes.add(ParserUtil.parseIndex(t));
+        }
+
+        if (paymentIndexes.isEmpty()) {
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, DeletePaymentCommand.MESSAGE_USAGE));
+        }
+
+        final java.util.Set<Integer> seen = new java.util.HashSet<>();
+        for (Index idx : paymentIndexes) {
+            int oneBased = idx.getOneBased();
+            if (!seen.add(oneBased)) {
+                throw new ParseException("Duplicate payment indexes are not allowed.");
+            }
+        }
+
+        return new DeletePaymentCommand(personIndex, paymentIndexes);
     }
 }


### PR DESCRIPTION
Changed the functionality of deletepayment to delete multiple payments from 1 person, rather than 1 payment from multiple people.

Changes viewpayment all to also include payments for archived members.

Fixes several bugs related to duplicate person index, duplicate payment index, duplicate p/ prefixes, error messages.

**IMPORTANT: Unit and integration test files for DeletePaymentCommand and its parser have not been updated! to be done by @enamourous** 

Fixes #123 #148 #156 #163 #128 #129 